### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -178,11 +178,11 @@ class GeocodeFetch(threading.Thread):
         for i in xrange(0, lineCount):
           evalLogDict[title][responseKey].append(message)
 
-      if (responseOld == None and responseNew == None):
+      if (responseOld is None and responseNew is None):
         pass
-      elif (responseOld == None and responseNew != None):
+      elif (responseOld is None and responseNew is not None):
         evallog('error from OLD, something from NEW')
-      elif (responseNew == None and responseOld != None):
+      elif (responseNew is None and responseOld is not None):
         evallog('error from NEW, something from OLD')
       elif (len(responseOld['interpretations']) == 0 and
           len(responseNew['interpretations']) > 0):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:twofishes?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:twofishes?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
